### PR TITLE
Allow for the custom domain

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.ivanasimic.online

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:3000
+

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue + TS</title>
+    <title>Hello world</title>
   </head>
   <body>
     <div id="app"></div>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -10,7 +10,7 @@ import { get as getHello } from "@/api/hello";
 import { get as getGoodbye } from "@/api/goodbye";
 import { ref } from "vue";
 
-const msg = ref("Pulumi static");
+const msg = ref("Klikni, aj klikni");
 
 const handleHello = async () => {
   const response = await getHello();

--- a/app/src/api/request.ts
+++ b/app/src/api/request.ts
@@ -1,9 +1,9 @@
 import axios from "axios";
 
-// TODO: import url from env depending on the stack
+const baseUrl = import.meta.env.VITE_API_URL;
+
 const request = axios.create({
-  baseURL:
-    "http://lb-20250825080459426200000002-697227279.us-east-1.elb.amazonaws.com",
+  baseURL: baseUrl,
   headers: { "Content-Type": "application/json" },
 });
 

--- a/infrastructure/Pulumi.dev.yaml
+++ b/infrastructure/Pulumi.dev.yaml
@@ -1,3 +1,4 @@
 config:
   pulumi-s3:siteDir: test
   pulumi-s3:name: ecs-s3
+  customDomain: ivanasimic.online

--- a/infrastructure/Pulumi.test.yaml
+++ b/infrastructure/Pulumi.test.yaml
@@ -1,0 +1,4 @@
+config:
+  ecs-s3-custom:siteDir: dir
+  ecs-s3-custom:name: ecs-s3-custom-domain
+  customDomain: ivanasimic.online

--- a/infrastructure/Pulumi.yaml
+++ b/infrastructure/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: pulumi-s3
+name: ecs-s3-custom
 description: A minimal AWS TypeScript Pulumi program
 runtime:
   name: nodejs

--- a/infrastructure/components/acm-certificate.ts
+++ b/infrastructure/components/acm-certificate.ts
@@ -1,4 +1,5 @@
 import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
 import { ComponentResource, Output } from "@pulumi/pulumi";
 
 type ComponentArgs = {
@@ -9,8 +10,12 @@ export class AcmCertificate extends ComponentResource {
   certificate: aws.acm.Certificate;
   validation: aws.acm.CertificateValidation;
 
-  constructor(name: string, componentArgs: ComponentArgs) {
-    super("pulumiS3:acm:Certificate", name, {}, {});
+  constructor(
+    name: string,
+    componentArgs: ComponentArgs,
+    opts: pulumi.ComponentResourceOptions = {}
+  ) {
+    super("pulumiS3:acm:Certificate", name, {}, opts);
 
     this.certificate = new aws.acm.Certificate(
       `${componentArgs.domainName}-certificate`,

--- a/infrastructure/components/backend-service.ts
+++ b/infrastructure/components/backend-service.ts
@@ -2,28 +2,15 @@ import * as pulumi from "@pulumi/pulumi";
 import * as awsx from "@pulumi/awsx";
 import * as aws from "@pulumi/aws";
 
+type ComponentArgs = {
+  imageUri: pulumi.Output<string>;
+};
+
 export class BackendService extends pulumi.ComponentResource {
   lb: aws.lb.LoadBalancer;
 
-  constructor(name: string) {
+  constructor(name: string, componentArgs: ComponentArgs) {
     super("pulumi:ECS", name, {}, {});
-    // TODO: extract repo, image and cluster
-    const repository = new awsx.ecr.Repository(
-      `${name}-ecr-repository`,
-      {
-        forceDelete: true,
-      },
-      { parent: this }
-    );
-
-    const image = new awsx.ecr.Image(
-      `${name}-image`,
-      {
-        repositoryUrl: repository.url,
-        context: "../server",
-      },
-      { parent: this }
-    );
 
     const cluster = new aws.ecs.Cluster(`${name}-cluster`);
 
@@ -152,7 +139,7 @@ export class BackendService extends pulumi.ComponentResource {
         taskDefinitionArgs: {
           container: {
             name: `${name}-container`,
-            image: image.imageUri,
+            image: componentArgs.imageUri,
             cpu: 128,
             memory: 512,
             essential: true,

--- a/infrastructure/components/ecr-image.ts
+++ b/infrastructure/components/ecr-image.ts
@@ -1,0 +1,28 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as awsx from "@pulumi/awsx";
+
+export class EcrImage extends pulumi.ComponentResource {
+  image: awsx.ecr.Image;
+
+  constructor(name: string) {
+    super("pulumi:ECR:image", name, {}, {});
+    const repository = new awsx.ecr.Repository(
+      `${name}-ecr-repository`,
+      {
+        forceDelete: true,
+      },
+      { parent: this }
+    );
+
+    this.image = new awsx.ecr.Image(
+      `${name}-image`,
+      {
+        repositoryUrl: repository.url,
+        context: "../server",
+      },
+      { parent: this }
+    );
+
+    this.registerOutputs();
+  }
+}

--- a/infrastructure/components/ecr-image.ts
+++ b/infrastructure/components/ecr-image.ts
@@ -5,7 +5,7 @@ export class EcrImage extends pulumi.ComponentResource {
   image: awsx.ecr.Image;
 
   constructor(name: string) {
-    super("pulumi:ECR:image", name, {}, {});
+    super("pulumi:ECR", name, {}, {});
     const repository = new awsx.ecr.Repository(
       `${name}-ecr-repository`,
       {

--- a/infrastructure/components/static-site.ts
+++ b/infrastructure/components/static-site.ts
@@ -45,7 +45,11 @@ export class StaticSite extends ComponentResource {
       new DnsRecord(name, {
         hostedZone,
         domainName: customDomainName,
-        cloudfrontDistribution: cloudfront.distribution,
+        target: {
+          dnsName: cloudfront.distribution.domainName,
+          zoneId: cloudfront.distribution.hostedZoneId,
+          evaluateTargetHealth: false,
+        },
       });
 
     this.registerOutputs();

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -1,5 +1,6 @@
 import { StaticSite } from "./components/static-site";
 import { BackendService } from "./components/backend-service";
+import { EcrImage } from "./components/ecr-image";
 import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
@@ -8,7 +9,8 @@ const name = config.require("name");
 const customDomainName = config.get("customDomain");
 
 const site = new StaticSite(name, { customDomainName, siteDir });
-const backend = new BackendService(name);
+const ecrImage = new EcrImage(name);
+const backend = new BackendService(name, { imageUri: ecrImage.image.imageUri });
 
 export const websiteUrl = site.siteBucket.siteConfig.websiteEndpoint;
 export const bucketId = site.siteBucket.bucket.id;

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -10,7 +10,10 @@ const customDomainName = config.get("customDomain");
 
 const site = new StaticSite(name, { customDomainName, siteDir });
 const ecrImage = new EcrImage(name);
-const backend = new BackendService(name, { imageUri: ecrImage.image.imageUri });
+const backend = new BackendService(name, {
+  customDomainName,
+  imageUri: ecrImage.image.imageUri,
+});
 
 export const websiteUrl = site.siteBucket.siteConfig.websiteEndpoint;
 export const bucketId = site.siteBucket.bucket.id;


### PR DESCRIPTION
- Map backend to `api.<custom_domain>`
- Update DNSRecord component to support both cloudfront distribution and application load balancer
- Extract ECR repo and image creation to a separate `EcrImage` component